### PR TITLE
Refactor hanna

### DIFF
--- a/PasswordManager/Client.cs
+++ b/PasswordManager/Client.cs
@@ -9,8 +9,6 @@ namespace PasswordManager
     {
         private string _path;
         private int _lengthOfKey = 16;
-        private string _secretKey;
-        public string SecretKey => _secretKey;
         public byte[] SecretKeyAsBytes { get; private set; }
 
         public Client(string path)
@@ -18,46 +16,24 @@ namespace PasswordManager
             _path = path;
         }
 
-        public void GenerateSecretKey()
+        public string GenerateSecretKey()
         {
             RandomNumberGenerator generator = RandomNumberGenerator.Create();
             SecretKeyAsBytes = new byte[_lengthOfKey];
             generator.GetBytes(SecretKeyAsBytes);
-        }
-
-        public void FormatAndSaveSecretKeyToJSON()
-        {
-            // Convert secret key(?) from byte[] to string.
-            _secretKey = Convert.ToBase64String(SecretKeyAsBytes);
-
-            Dictionary<string, string> secretKeys = new Dictionary<string, string>();
-            secretKeys.Add("secret", _secretKey);
-
-            string jsonDictAsString = JsonSerializer.Serialize(secretKeys);
-            File.WriteAllText(_path, jsonDictAsString);
+            return Convert.ToBase64String(SecretKeyAsBytes);
         }
 
         public Rfc2898DeriveBytes DeriveVaultKey()
         {
-            // master password + secret key + Rfc2898DeriveBytes = vault key
             Console.WriteLine("Enter your master password: ");
             return new Rfc2898DeriveBytes(Console.ReadLine(), SecretKeyAsBytes, 10000, HashAlgorithmName.SHA256);
         }
 
         public Rfc2898DeriveBytes DeriveVaultKey(string secretKey)
         {
-            // master password + secret key + Rfc2898DeriveBytes = vault key
-            byte[] secretKeyAsBytes = Encoding.UTF8.GetBytes(secretKey);
-            Console.WriteLine("Enter your master password: ");
-            return new Rfc2898DeriveBytes(Console.ReadLine(), secretKeyAsBytes, 10000, HashAlgorithmName.SHA256);
-        }
-
-        private static string GetValueFromJSONFile(string pathToFile, string key)
-        {
-            // string secret = GetValueFromJSONFile(args[1], "secret"); 
-            string fileAsText = File.ReadAllText(pathToFile);
-            Dictionary<string, string> KeyValuePairs = JsonSerializer.Deserialize<Dictionary<string, string>>(fileAsText);
-            return KeyValuePairs[key];
+            SecretKeyAsBytes = Encoding.UTF8.GetBytes(secretKey);
+            return DeriveVaultKey();
         }
     }
 }

--- a/PasswordManager/Client.cs
+++ b/PasswordManager/Client.cs
@@ -1,5 +1,6 @@
 ﻿
 using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 
 namespace PasswordManager
@@ -15,20 +16,16 @@ namespace PasswordManager
         public Client(string path)
         {
             _path = path;
-            GenerateSecretKey();
-            FormatAndSaveSecretKeyToJSON();
-
-            Console.WriteLine($"The secret key is: {_secretKey}");
         }
 
-        private void GenerateSecretKey()
+        public void GenerateSecretKey()
         {
             RandomNumberGenerator generator = RandomNumberGenerator.Create();
             SecretKeyAsBytes = new byte[_lengthOfKey];
             generator.GetBytes(SecretKeyAsBytes);
         }
 
-        private void FormatAndSaveSecretKeyToJSON()
+        public void FormatAndSaveSecretKeyToJSON()
         {
             // Convert secret key(?) from byte[] to string.
             _secretKey = Convert.ToBase64String(SecretKeyAsBytes);
@@ -45,6 +42,14 @@ namespace PasswordManager
             // master password + secret key + Rfc2898DeriveBytes = vault key
             Console.WriteLine("Enter your master password: ");
             return new Rfc2898DeriveBytes(Console.ReadLine(), SecretKeyAsBytes, 10000, HashAlgorithmName.SHA256);
+        }
+
+        public Rfc2898DeriveBytes DeriveVaultKey(string secretKey)
+        {
+            // master password + secret key + Rfc2898DeriveBytes = vault key
+            byte[] secretKeyAsBytes = Encoding.UTF8.GetBytes(secretKey);
+            Console.WriteLine("Enter your master password: ");
+            return new Rfc2898DeriveBytes(Console.ReadLine(), secretKeyAsBytes, 10000, HashAlgorithmName.SHA256);
         }
 
         private static string GetValueFromJSONFile(string pathToFile, string key)

--- a/PasswordManager/FileHandler.cs
+++ b/PasswordManager/FileHandler.cs
@@ -1,0 +1,29 @@
+﻿
+using System.Text.Json;
+
+namespace PasswordManager
+{
+    internal class FileHandler
+    {
+        public void WriteToJson(string path, string keyText, string valueText)
+        {
+            Dictionary<string, string> keyValuePairs = new Dictionary<string, string>
+            {
+                { keyText, valueText }
+            };
+
+            string jsonDictAsString = JsonSerializer.Serialize(keyValuePairs);
+
+            File.WriteAllText(path, jsonDictAsString);
+        }
+
+        public string ReadValueFromJson(string path, string keyText)
+        {
+            string fileAsText = File.ReadAllText(path);
+
+            // Deserialize jsontext to Dictionary<string, string>.
+            Dictionary<string, string> KeyValuePairs = JsonSerializer.Deserialize<Dictionary<string, string>>(fileAsText);
+            return KeyValuePairs[keyText];
+        }
+    }
+}

--- a/PasswordManager/Program.cs
+++ b/PasswordManager/Program.cs
@@ -1,5 +1,6 @@
 ﻿
 using System.Security.Cryptography;
+using System.Text;
 
 namespace PasswordManager
 {
@@ -36,7 +37,13 @@ namespace PasswordManager
         {
             
             Client client = new Client(args[1]);
+            client.GenerateSecretKey();
+            client.FormatAndSaveSecretKeyToJSON();
+
             Server server = new Server(args[2]);
+            server.GenerateInitializationVector();
+            // server.FormatAndSaveIVToJSON();
+
             server.CreateVault();
 
             Rfc2898DeriveBytes vaultKey = client.DeriveVaultKey();
@@ -47,11 +54,18 @@ namespace PasswordManager
         // "create"-command
         private static void CreateNewClientFileToExistingVault(string[] args)
         {
-            string encryptedVaultAsText = File.ReadAllText(args[2]);
+            Client client = new Client(args[1]);
             Server server = new Server(args[2]);
-            Rfc2898DeriveBytes vaultKey = client.DeriveVaultKey();
-            string decryptedVault = server.Decrypt(vaultKey);
-            Console.WriteLine("Enter master password: ");
+
+            Console.WriteLine("Enter your secret key: ");
+            string secretKey = Console.ReadLine();
+            Rfc2898DeriveBytes vaultKey = client.DeriveVaultKey(secretKey);
+
+            string encryptedVaultAsText = File.ReadAllText(args[2]);
+            byte[] encryptedVaultAsBytes = Encoding.UTF8.GetBytes(encryptedVaultAsText);
+            string decryptedVault = server.Decrypt(encryptedVaultAsBytes, vaultKey);
+            Console.WriteLine(decryptedVault);
+
         }
 
         // "get"-command


### PR DESCRIPTION
- Moved business logic from constructors in Server and Client, and made those methods public. 
- Removed string property secretKey in Client, it is not needed because when we need it we can read from client.json file as string. Inside of the Client class it is only needed as a byte[].
- GenerateSecretKey() method in Client will return the secret key as string, and update the internal byte[] SercretKey to the obtained value.
- Added formatting to the command so it will always be lowercase (args[0].ToLower()) before entering the switch statement in Main.
- Renamed mathod "CreateNewVault" to "InitializeVault".
- Added class FileHandler to handle writing and reading from files, which also does the required formating to be able to write/read the values.
- Because of the FileHandler class, I removed the methods that reads/writes to JSON inside the Client and Server classes, except the method in Server (WriteIVAndEncryptedVaultToJSON) which is a bit special at the moment, which writes both the IV and Vault to server.json. The value in vault is its own dictionary with domains and passwords and is encrypted. The IV value is not encrypted. There would certainly be a better way of doing this but I'm not currently sure how.
- Also added a method overload for DeriveVaultKey() in Client to be able to decrypt by asking user for both secret key and master password.