### PR TITLE
Did some refactoring.

### DIFF
--- a/PasswordManager/Client.cs
+++ b/PasswordManager/Client.cs
@@ -6,7 +6,7 @@ namespace PasswordManager
     internal class Client
     {
         private string _path;
-        private int _lengthOfKey = 16;
+        private readonly int _lengthOfKey = 16;
         public byte[] SecretKeyAsBytes;
 
         public Client(string path)
@@ -14,25 +14,76 @@ namespace PasswordManager
             _path = path;
         }
 
-        public string GenerateSecretKey()
+        public string PromptUser(string prompt)
+        {
+            string input = "";
+
+            while (input == "")
+            {
+                Console.WriteLine($"Enter the {prompt}: ");
+                input = Console.ReadLine();
+                if (input == "")
+                {
+                    Console.WriteLine($"The {prompt} cannot be empty.");
+                }
+            }
+
+            return input;
+        }
+
+        public void Initialize()
+        {
+            GenerateSecretKey();
+            string secretKey = GetSecretKeyAsText();
+            FileHandler fileHandler = new FileHandler();
+            fileHandler.WriteToJson(_path, "secret", secretKey);
+        }
+
+        public void GenerateSecretKey()
         {
             using (RandomNumberGenerator generator = RandomNumberGenerator.Create())
             {
                 SecretKeyAsBytes = new byte[_lengthOfKey];
                 generator.GetBytes(SecretKeyAsBytes);
             }
+        }
 
+        public string GetSecretKeyAsText()
+        {
             return Convert.ToBase64String(SecretKeyAsBytes);
         }
 
-        public void SetSecretKey(string secretKeyAsString)
+        public void ReadAndSetSecretKey()
         {
-            SecretKeyAsBytes = Convert.FromBase64String(secretKeyAsString);
+            FileHandler fileHandler = new FileHandler();
+            try
+            {
+                string secretKeyAsText = fileHandler.ReadValueFromJson(_path, "secret");
+                SecretKeyAsBytes = Convert.FromBase64String(secretKeyAsText);
+            }
+            catch
+            {
+                Console.WriteLine("Could not read from file.");
+            }
         }
 
-        public Rfc2898DeriveBytes Authenticate(string masterPassword)
+        public void SetSecretKey(string secretKey)
         {
-            return new Rfc2898DeriveBytes(masterPassword, SecretKeyAsBytes, 10000, HashAlgorithmName.SHA256);
+            try
+            {
+                SecretKeyAsBytes = Convert.FromBase64String(secretKey);
+            }
+            catch
+            {
+                Console.WriteLine("Something went wrong.");
+                return;
+            }
+        }
+
+        public byte[] GetVaultKey(string masterPassword)
+        {
+            Rfc2898DeriveBytes authentication = new Rfc2898DeriveBytes(masterPassword, SecretKeyAsBytes, 10000, HashAlgorithmName.SHA256);
+            return authentication.GetBytes(16);
         }
     }
 }

--- a/PasswordManager/Properties/launchSettings.json
+++ b/PasswordManager/Properties/launchSettings.json
@@ -5,42 +5,42 @@
     },
     "Init": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\blanc\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
+      "executablePath": "C:\\Users\\Laptop\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
       "commandLineArgs": "init client.json server.json"
     },
     "Create": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\blanc\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
+      "executablePath": "C:\\Users\\Laptop\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
       "commandLineArgs": "create client2.json server.json"
     },
     "Get": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\blanc\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
+      "executablePath": "C:\\Users\\Laptop\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
       "commandLineArgs": "get client.json server.json "
     },
     "Set": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\blanc\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
+      "executablePath": "C:\\Users\\Laptop\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
       "commandLineArgs": "set client.json server.json gmail.com"
     },
     "Set and randomize new": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\blanc\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
+      "executablePath": "C:\\Users\\Laptop\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
       "commandLineArgs": "set client.json server.json messenger -g"
     },
     "Get prop password": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\blanc\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
+      "executablePath": "C:\\Users\\Laptop\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
       "commandLineArgs": "get client.json server.json messenger"
     },
     "Delete": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\blanc\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
+      "executablePath": "C:\\Users\\Laptop\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
       "commandLineArgs": "delete client.json server.json gmail.com"
     },
     "Secret": {
       "commandName": "Executable",
-      "executablePath": "C:\\Users\\blanc\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
+      "executablePath": "C:\\Users\\Laptop\\source\\repos\\PasswordManager\\PasswordManager\\bin\\Debug\\net8.0\\PasswordManager.exe",
       "commandLineArgs": "secret client.json "
     }
   }


### PR DESCRIPTION
- Method to prompt user, used for both master password, secret key and username for which to store a new password.
- Added more error handling, for example a try-catch when trying to read the secret key from client.json.
- Added a bool checker in the beginning of each method to proceed only if the number of arguments is valid.
- Shortened the init method by using a method Initialize() on both the client and the server instances.
- Renamed "VaultValues" to simply "Accounts" to minimize possible confusion that can occur when trying to differentiate between Vault and VaultValues.